### PR TITLE
New styles 'Punctuation' and 'Overloaded Operator'

### DIFF
--- a/dracula.xml
+++ b/dracula.xml
@@ -26,6 +26,8 @@
   <style name="Keyword" foreground="#ff79c6" bold="true"/>
   <style name="PrimitiveType" foreground="#7ce4fb" italic="true"/>
   <style name="Operator" foreground="#ffffff"/>
+  <style name="Overloaded Operator" foreground="#ffb86c"/>
+  <style name="Punctuation"/>
   <style name="Preprocessor" foreground="#ff79c6"/>
   <style name="Label" foreground="#ffb86c"/>
   <style name="Comment" foreground="#6272a4" bold="true"/>


### PR DESCRIPTION
> New style for 'Overloaded Operator' was not covered yet. Default is too close to background color. Added style with color "orange". Also added style for 'puctuation'. default is fine here.
![old](https://user-images.githubusercontent.com/50018017/73133408-78561b80-4028-11ea-9849-3c070f700408.png)
![new](https://user-images.githubusercontent.com/50018017/73133409-79874880-4028-11ea-8f0c-392b97f0c1bc.png)

