### PR TITLE
New style "Parameter"

### DIFF
--- a/dracula.xml
+++ b/dracula.xml
@@ -18,6 +18,7 @@
   <style name="String" foreground="#f1fa8c"/>
   <style name="Type" foreground="#7ce4fb"/>
   <style name="Local" foreground="#ffffff"/>
+  <style name="Parameter"/>
   <style name="Global" foreground="#ffb86c"/>
   <style name="Field" foreground="#ffffff"/>
   <style name="Static" foreground="#ffb86c"/>


### PR DESCRIPTION
New style "Parameter " was introduced with Qt Creator 5. If not present in xml, it'll become dark blue and nearly indistinguishable from the background.

without "Parameter"
![broken](https://user-images.githubusercontent.com/50018017/130973249-150c3b7c-89b8-4721-98bd-4a2f615afd38.png)
with "Parameter"
![fixed](https://user-images.githubusercontent.com/50018017/130973262-1270ffb7-7a32-46a2-8d2d-3d8eb5320bc9.png)
