### PR TITLE
Qt Creator 7.0.0 - Correctly highlight Static Members

### DIFF
--- a/dracula.xml
+++ b/dracula.xml
@@ -65,5 +65,5 @@
   <style name="Declaration" bold="true"/>
   <style name="FunctionDefinition"/>
   <style name="OutputArgument" italic="true"/>
-  <style name="StaticMember" underlineColor="#ffb86c"/>
+  <style name="StaticMember" foreground="#ffb86c"/>
 </style-scheme>

--- a/dracula.xml
+++ b/dracula.xml
@@ -65,4 +65,5 @@
   <style name="Declaration" bold="true"/>
   <style name="FunctionDefinition"/>
   <style name="OutputArgument" italic="true"/>
+  <style name="StaticMember" underlineColor="#ffb86c"/>
 </style-scheme>


### PR DESCRIPTION
> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.

Before: 
![image](https://user-images.githubusercontent.com/35696968/163049817-930cf827-20e4-43cd-8aa2-82ef2dc571b3.png)

After:
![image](https://user-images.githubusercontent.com/35696968/163049938-4535bdb8-80df-422f-887a-bbf7defd88d3.png)
