### PR TITLE
Add light purple coloring to Class Field variables

### DIFF
--- a/dracula.xml
+++ b/dracula.xml
@@ -20,7 +20,7 @@
   <style name="Local" foreground="#ffffff"/>
   <style name="Parameter"/>
   <style name="Global" foreground="#ffb86c"/>
-  <style name="Field" foreground="#ffffff"/>
+  <style name="Field" foreground="#e1cbff"/>
   <style name="Static" foreground="#ffb86c"/>
   <style name="VirtualMethod" foreground="#50fa7b" italic="true"/>
   <style name="Function" foreground="#50fa7b"/>


### PR DESCRIPTION
Qt Creator supports highlighting class field members differently than locally-declared variables. This change makes it more obvious to differentiate class members from other variables, without using a distracting color.

> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.

Before:
![image](https://user-images.githubusercontent.com/35696968/163050176-efaa96f6-8812-4bb7-99ab-9553d94aea9a.png)

After:
![image](https://user-images.githubusercontent.com/35696968/163050252-ff949270-ef69-4b8e-b427-87e3f1eea9ce.png)
