### PR TITLE
drakula.creatortheme: fix black colors for "Terminal" tab

### DIFF
--- a/drakula.creatortheme
+++ b/drakula.creatortheme
@@ -372,6 +372,27 @@ PaletteBaseDisabled=backgroundColorDisabled
 PaletteTextDisabled=textDisabled
 PaletteMid=ffa0a0a0
 
+TerminalForeground=f8f8f2
+TerminalBackground=282a36
+TerminalSelection=44475a
+TerminalFindMatch=ffb86c
+TerminalAnsi0=000000
+TerminalAnsi1=ff5555
+TerminalAnsi2=50fa7b
+TerminalAnsi3=f1fa8c
+TerminalAnsi4=bd93f9
+TerminalAnsi5=ff79c6
+TerminalAnsi6=8be9fd
+TerminalAnsi7=f8f8f2
+TerminalAnsi8=6272a4
+TerminalAnsi9=ff6e6e
+TerminalAnsi10=69ff94
+TerminalAnsi11=ffffa5
+TerminalAnsi12=d6acff
+TerminalAnsi13=ff92df
+TerminalAnsi14=a4ffff
+TerminalAnsi15=ffffff
+
 [Flags]
 ComboBoxDrawTextShadow=false
 DerivePaletteFromTheme=true


### PR DESCRIPTION
Fixes black "Terminal" tab in my setup. As I'm awful with colors, the change was eyeballed a bit and then double checked with suggestions from chatGPT. This is how it looks after the change:

![qtcreator-terminal-colors-fix](https://github.com/user-attachments/assets/4b450a12-5461-4fb1-a5c4-c2a738906d9a)